### PR TITLE
Added github_oidc_provider_component_name variable

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -28,6 +28,7 @@ module "gha_assume_role" {
   source = "../account-map/modules/team-assume-role-policy"
 
   trusted_github_repos = var.github_actions_allowed_repos
+  github_oidc_provider_component_name = var.github_oidc_provider_component_name
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -44,7 +44,6 @@ variable "iam_policy" {
   nullable    = false
 }
 
-
 variable "github_actions_allowed_repos" {
   type        = list(string)
   description = <<EOF
@@ -53,4 +52,10 @@ variable "github_actions_allowed_repos" {
   If org part of repo name is omitted, "cloudposse" will be assumed.
   EOF
   default     = []
+}
+
+variable "github_oidc_provider_component_name" {
+  type        = string
+  description = "The name of the github-oidc-provider component"
+  default     = "github-oidc-provider"
 }


### PR DESCRIPTION
Allow the user to specify the GitHub OIDC component name:
* Added a new variable `github_oidc_provider_component_name` to allow passing its value through to `github-assume-role-policy.mixin.tf` in `aws-account-map/modules/team-assume-role-policy`.  
* The default value (`github-oidc-provider`) preserves existing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub OIDC provider component name is now configurable (defaults to "github-oidc-provider").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->