### PR TITLE
Add max_session_duration to IAM role configuration

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -37,6 +37,8 @@ resource "aws_iam_role" "github_actions" {
 
   name               = module.this.id
   assume_role_policy = module.gha_assume_role.github_assume_role_policy
+  
+  max_session_duration = var.max_session_duration
 
   managed_policy_arns = local.policies
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -37,7 +37,6 @@ resource "aws_iam_role" "github_actions" {
 
   name               = module.this.id
   assume_role_policy = module.gha_assume_role.github_assume_role_policy
-  
   max_session_duration = var.max_session_duration
 
   managed_policy_arns = local.policies

--- a/src/main.tf
+++ b/src/main.tf
@@ -35,8 +35,8 @@ module "gha_assume_role" {
 resource "aws_iam_role" "github_actions" {
   count = local.enabled ? 1 : 0
 
-  name               = module.this.id
-  assume_role_policy = module.gha_assume_role.github_assume_role_policy
+  name                 = module.this.id
+  assume_role_policy   = module.gha_assume_role.github_assume_role_policy
   max_session_duration = var.max_session_duration
 
   managed_policy_arns = local.policies

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -54,3 +54,9 @@ variable "github_actions_allowed_repos" {
   EOF
   default     = []
 }
+
+variable "max_session_duration" {
+  type        = number
+  description = "Maximum session duration (in seconds). This setting can have a value from 1 hour to 12 hours"
+  default     = 3600
+}


### PR DESCRIPTION
## what
* Add max_session_duration to IAM role configuration

## why
* Increase session durtion for long running jobs

## references
* https://sweetops.slack.com/archives/G014YEKDH4K/p1756980084638969
* https://github.com/cloudposse/terraform-aws-service-control-policies/actions/runs/17460058661/job/50713688780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IAM role session duration is now configurable. Users can customize authentication timeout settings to suit their infrastructure and workflow requirements, providing greater control over session management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->