### PR TITLE
fix: Remove deprecated Terraform syntax

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -5,7 +5,7 @@ locals {
   policy_document_map = {
     "gitops"        = local.gitops_policy
     "lambda_cicd"   = local.lambda_cicd_policy
-    "inline_policy" = one(module.iam_policy.*.json)
+    "inline_policy" = one(module.iam_policy[*].json)
   }
   custom_policy_map = merge(local.policy_document_map, local.overridable_additional_custom_policy_map)
 

--- a/src/policy_gitops.tf
+++ b/src/policy_gitops.tf
@@ -18,7 +18,7 @@ variable "gitops_policy_configuration" {
 
 locals {
   gitops_policy_enabled = contains(var.iam_policies, "gitops")
-  gitops_policy         = local.gitops_policy_enabled ? one(data.aws_iam_policy_document.gitops_iam_policy.*.json) : null
+  gitops_policy         = local.gitops_policy_enabled ? one(data.aws_iam_policy_document.gitops_iam_policy[*].json) : null
 
   s3_bucket_arn      = one(module.s3_bucket[*].outputs.bucket_arn)
   dynamodb_table_arn = one(module.dynamodb[*].outputs.table_arn)

--- a/src/policy_lambda-cicd.tf
+++ b/src/policy_lambda-cicd.tf
@@ -26,7 +26,7 @@ variable "lambda_cicd_policy_configuration" {
 
 locals {
   lambda_cicd_policy_enabled = contains(var.iam_policies, "lambda-cicd")
-  lambda_cicd_policy         = local.lambda_cicd_policy_enabled ? one(data.aws_iam_policy_document.lambda_cicd_policy.*.json) : null
+  lambda_cicd_policy         = local.lambda_cicd_policy_enabled ? one(data.aws_iam_policy_document.lambda_cicd_policy[*].json) : null
 
   lambda_bucket_arn = try(module.s3_artifacts_bucket[0].outputs.bucket_arn, null)
 }


### PR DESCRIPTION
## Why

Deprecated HCL syntax triggers linting warnings and will eventually be removed in future Terraform versions. Cleaning these up improves code quality, maintainability, and ensures forward compatibility.

## What

Automated fixes applied via `tflint --fix` with the following rules enabled:

| Rule | Description | Example |
|------|-------------|---------|
| `terraform_deprecated_interpolation` | Remove unnecessary interpolation wrappers | `"${var.foo}"` → `var.foo` |
| `terraform_deprecated_index` | Replace legacy dot-index syntax | `list.0` → `list[0]` |
| `terraform_deprecated_lookup` | Replace deprecated `lookup()` calls | `lookup(map, key)` → `map[key]` |

## References

- [tflint terraform_deprecated_interpolation](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md)
- [tflint terraform_deprecated_index](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_index.md)
- [tflint terraform_deprecated_lookup](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_lookup.md)
- [Terraform: References to Named Values](https://developer.hashicorp.com/terraform/language/expressions/references)