### PR TITLE
chore(deps): update stack-config/yaml to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,12 +248,12 @@ There are two methods for adding custom policies to the IAM role.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_dynamodb"></a> [dynamodb](#module\_dynamodb) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_dynamodb"></a> [dynamodb](#module\_dynamodb) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_gha_assume_role"></a> [gha\_assume\_role](#module\_gha\_assume\_role) | ../account-map/modules/team-assume-role-policy | n/a |
 | <a name="module_iam_policy"></a> [iam\_policy](#module\_iam\_policy) | cloudposse/iam-policy/aws | 2.0.2 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_s3_artifacts_bucket"></a> [s3\_artifacts\_bucket](#module\_s3\_artifacts\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_s3_artifacts_bucket"></a> [s3\_artifacts\_bucket](#module\_s3\_artifacts\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/src/README.md
+++ b/src/README.md
@@ -197,12 +197,12 @@ There are two methods for adding custom policies to the IAM role.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_dynamodb"></a> [dynamodb](#module\_dynamodb) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_dynamodb"></a> [dynamodb](#module\_dynamodb) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_gha_assume_role"></a> [gha\_assume\_role](#module\_gha\_assume\_role) | ../account-map/modules/team-assume-role-policy | n/a |
 | <a name="module_iam_policy"></a> [iam\_policy](#module\_iam\_policy) | cloudposse/iam-policy/aws | 2.0.2 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_s3_artifacts_bucket"></a> [s3\_artifacts\_bucket](#module\_s3\_artifacts\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_s3_artifacts_bucket"></a> [s3\_artifacts\_bucket](#module\_s3\_artifacts\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/src/policy_gitops.tf
+++ b/src/policy_gitops.tf
@@ -28,7 +28,7 @@ module "s3_bucket" {
   count = local.gitops_policy_enabled ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = lookup(var.gitops_policy_configuration, "s3_bucket_component_name", "gitops/s3-bucket")
   environment = lookup(var.gitops_policy_configuration, "s3_bucket_environment_name", module.this.environment)
@@ -40,7 +40,7 @@ module "dynamodb" {
   count = local.gitops_policy_enabled ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = lookup(var.gitops_policy_configuration, "dynamodb_component_name", module.this.environment)
   environment = lookup(var.gitops_policy_configuration, "dynamodb_environment_name", module.this.environment)

--- a/src/policy_lambda-cicd.tf
+++ b/src/policy_lambda-cicd.tf
@@ -35,7 +35,7 @@ module "s3_artifacts_bucket" {
   count = lookup(var.lambda_cicd_policy_configuration, "enable_s3_access", false) ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = lookup(var.lambda_cicd_policy_configuration, "s3_bucket_component_name", "s3-bucket/github-action-artifacts")
   environment = lookup(var.lambda_cicd_policy_configuration, "s3_bucket_environment_name", module.this.environment)


### PR DESCRIPTION
## Why

Shared CI vendors the current `aws-account-map`, which uses `cloudposse/stack-config/yaml` v2.0.0 and requires `cloudposse/utils >= 2.0.0, < 3.0.0`. This component still used stack-config v1.8.0, which requires `cloudposse/utils < 2.0.0`, so `terraform init` could not resolve a provider version.

This recreates the dependency upgrade from #43. It should merge before #48 is returned to the merge queue.

## What

- update all three remote-state modules from stack-config v1.8.0 to v2.0.0
- update the generated module version tables

## Verification

- Terraform 1.13.5 `init -backend=false` succeeded with the current `aws-account-map` modules and selected `cloudposse/utils` v2.6.0
- `terraform validate` passed
- `terraform fmt -check -recursive` passed